### PR TITLE
Upgrade AWS Java SDK to support for EMR releases

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ scalaVersion := "2.10.3"
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-language:_")
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk" % "1.8.2",
+  "com.amazonaws" % "aws-java-sdk" % "1.10.16",
   "com.googlecode.json-simple" % "json-simple" % "1.1.1",
   "commons-lang" % "commons-lang" % "2.6",
   "junit" % "junit" % "4.10" % "test",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
 
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.5.0")
 

--- a/src/main/scala/com/bizo/hive/sparkplug/emr/application.scala
+++ b/src/main/scala/com/bizo/hive/sparkplug/emr/application.scala
@@ -1,0 +1,31 @@
+package com.bizo.hive.sparkplug.emr
+
+import com.amazonaws.services.elasticmapreduce.model.{Application => AwsApplication}
+
+import java.util.Collection
+
+import scala.collection.JavaConverters._
+
+case class Application(
+  val name: String,
+  val version: Option[String] = None,
+  val args: Option[List[String]] = None,
+  val additionalInfo: Option[Map[String, String]] = None
+)
+
+trait ApplicationImplicits {
+  implicit def application2AwsApplication(a: Application): AwsApplication = {
+    val awsApp = new AwsApplication()
+      .withName(a.name)
+      .withVersion(a.version.orNull)
+
+    a.args.foreach { args => awsApp.setArgs(args.asJava) }
+    a.additionalInfo.foreach { infos => awsApp.setAdditionalInfo(infos.asJava) }
+
+    awsApp
+  }
+
+  implicit def applicationList2Java(l: Seq[Application]): Collection[AwsApplication] = {
+    l.map(application2AwsApplication).asJava
+  }
+}

--- a/src/main/scala/com/bizo/hive/sparkplug/emr/config.scala
+++ b/src/main/scala/com/bizo/hive/sparkplug/emr/config.scala
@@ -5,6 +5,7 @@ trait ClusterConfig {
   def logUri: Option[String] = None
   def sshKeyPair: Option[String] = None
   def amiVersion: Option[String] = None
+  def releaseLabel: Option[String] = None
   def defaultMasterSize: String = "m1.large"
   def defaultCoreSize: String = "m1.xlarge"
   def defaultTaskSize: String = defaultCoreSize
@@ -13,6 +14,7 @@ trait ClusterConfig {
   def jobFlowRole: Option[String] = None
   def serviceRole: Option[String] = None
   def subnetId: Option[String] = None
+  def applications: Option[Seq[Application]] = None
 }
 
 class DefaultBidProvider extends BidProvider {
@@ -25,13 +27,13 @@ class DefaultBidProvider extends BidProvider {
     "m1.medium" -> 0.087,
     "m1.large"  -> 0.175,
     "m1.xlarge" -> 0.350,
-    
+
     // Compute Optimized - Previous Generation
     "c1.medium"   -> 0.130,
     "c1.xlarge"   -> 0.520,
     "cc2.8xlarge" -> 2.000,
     "cc1.4xlarge" -> 1.300,
-    
+
     // GPU Instances - Previous Generation
     "cg1.4xlarge" -> 2.100,
 
@@ -40,13 +42,13 @@ class DefaultBidProvider extends BidProvider {
     "m2.2xlarge"  -> 0.490,
     "m2.4xlarge"  -> 0.980,
     "cr1.8xlarge" -> 3.500,
-    
+
     // Storage Optimized - Previous Generation
     "hi1.4xlarge" -> 3.100,
-    
+
     // Micro Instances - Previous Generation
-    "t1.micro" -> 0.020,    
-    
+    "t1.micro" -> 0.020,
+
     // General Purpose - Current Generation
     "t2.micro"    -> 0.013,
     "t2.small"    -> 0.026,
@@ -55,24 +57,24 @@ class DefaultBidProvider extends BidProvider {
     "m3.large"    -> 0.140,
     "m3.xlarge"   -> 0.280,
     "m3.2xlarge"  -> 0.560,
-    
+
     // Compute Optimized - Current Generation
     "c3.large"   -> 0.105,
     "c3.xlarge"  -> 0.210,
     "c3.2xlarge" -> 0.420,
     "c3.4xlarge" -> 0.840,
     "c3.8xlarge" -> 1.680,
-    
+
     // GPU Instances - Current Generation
     "g2.2xlarge" -> 0.650,
-    
+
     // Memory Optimized - Current Generation
     "r3.large"   -> 0.175,
     "r3.xlarge"  -> 0.350,
     "r3.2xlarge" -> 0.700,
     "r3.4xlarge" -> 1.400,
     "r3.8xlarge" -> 2.800,
-    
+
     // Storage Optimized - Current Generation
     "i2.xlarge"   -> 0.853,
     "i2.2xlarge"  -> 1.705,

--- a/src/main/scala/com/bizo/hive/sparkplug/emr/package.scala
+++ b/src/main/scala/com/bizo/hive/sparkplug/emr/package.scala
@@ -1,7 +1,7 @@
 package com.bizo.hive.sparkplug
 
 import com.bizo.hive.sparkplug.s3.S3
-package object emr {
+package object emr extends ApplicationImplicits {
   implicit def masterToCluster(m: Master) = new Cluster[MasterDef, UnspecifiedDef, UnspecifiedDef](Set(m))
   implicit val defaultBidProvider: BidProvider = new DefaultBidProvider
   implicit lazy val s3: S3 = S3.defaultS3

--- a/src/test/scala/com/bizo/hive/sparkplug/emr/EmrTest.scala
+++ b/src/test/scala/com/bizo/hive/sparkplug/emr/EmrTest.scala
@@ -41,4 +41,22 @@ class EmrTest {
 
     assertEquals(expected, aws.jobFlowRequest.getSteps.map(_.getName).toSeq)
   }
+
+  @Test
+  def testPopulateApplications() {
+    val testConfig = new ClusterConfig {
+      override def applications = Some(Seq(
+        Application(name = "Spark")
+      ))
+    }
+
+    val flow = JobFlow("test", Master() + Core(4) + Spot(4), Seq())
+
+    emr.run(flow)(testConfig)
+
+    val expected = Seq("Spark")
+    val actual = aws.jobFlowRequest.getApplications.map(a => a.getName).toSeq
+
+    assertEquals(expected, actual)
+  }
 }


### PR DESCRIPTION
Java SDK release 1.10.6 introduces support for
"emr releases" detailed [here](https://docs.aws.amazon.com/ElasticMapReduce/latest/ReleaseGuide/emr-release-components.html)

This changeset introduces the ability to spawn EMR
clusters with emr-4.0.0, and also enables creating
EMR clusters with Spark preinstalled.

+ Added an DSL for adding Applications to JobFlowRequests
+ Added a SparkStep dsl + test